### PR TITLE
add dockerfile to project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# add a blank docker image
+FROM scratch
+WORKDIR /app
+# Now just add the binary and text files
+ADD . /app/
+ENTRYPOINT ["./eliza"]


### PR DESCRIPTION
Adding a dockerfile to create a small image for running the project over any docker client.

Requires some external building in order to run to keep the dockerfile small (~4). The iron/go:dev image is around 400mb but it's needed to compile the golang file.

Firstly run:
`docker run --rm -v "$PWD":/go/src/github.com/emerging-technologies/eliza -w /go/src/github.com/emerging-technologies/eliza iron/go:dev go build -o eliza`

Then you need to build the image:
`docker build -t ian/eliza .`

You can then run the project:
`docker run -it ian/eliza`

More detail on small docker images for golang can be found [here](https://blog.codeship.com/building-minimal-docker-containers-for-go-applications/ )

Padraic Wade